### PR TITLE
Standalone item support

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -48,10 +48,12 @@ local function startThreads()
             speedBuffer[1] = GetEntitySpeed(vehEntity) * speedunit
 
             -- Driveability handler (health, fuel)
-            local fuelLevel = GetVehicleFuelLevel(vehEntity)
-            if healthBuffer[1] <= 0 or fuelLevel <= 6.4 then
-                if IsVehicleDriveable(vehEntity, true) then
-                    SetVehicleUndriveable(vehEntity, true)
+            if GetResourceState('ox_fuel') ~= 'started' then
+                local fuelLevel = GetVehicleFuelLevel(vehEntity)
+                if healthBuffer[1] <= 0 or fuelLevel <= 6.4 then
+                    if IsVehicleDriveable(vehEntity, true) then
+                        SetVehicleUndriveable(vehEntity, true)
+                    end
                 end
             end
 
@@ -284,7 +286,7 @@ if GetResourceState('ox_inventory') == 'started' then
 
         SetVehicleDoorOpen(veh, doorIndex, false, false)
         lib.requestAnimDict('mini@repair')
-        TaskPlayAnim(cache.ped, 'mini@repair', 'fixing_a_player', 2.0, 2.0, -1, 1, 0, false, false, false) -- This might be changed
+        TaskPlayAnim(cache.ped, 'mini@repair', 'fixing_a_player', 2.0, 2.0, -1, 1, 0, false, false, false)
 
         local success = lib.skillCheck({'easy', 'easy', {areaSize = 60, speedMultiplier = 2}, 'hard'}, {'w', 'a', 's', 'd'})
         if success then
@@ -303,9 +305,9 @@ if GetResourceState('ox_inventory') == 'started' then
             end
             SetVehicleEngineOn(veh, true, false, false)
             SetVehicleDoorShut(veh, doorIndex, false)
-            ClearPedTasks(cache.ped) -- This might be changed
+            ClearPedTasks(cache.ped)
         else
-            ClearPedTasks(cache.ped) -- This might be changed
+            ClearPedTasks(cache.ped)
             lib.notify({
                 description = 'You have failed!',
                 position = 'top-right',
@@ -322,7 +324,7 @@ if GetResourceState('ox_inventory') == 'started' then
 
         SetVehicleDoorOpen(veh, doorIndex, false, false)
         lib.requestAnimDict('mini@repair')
-        TaskPlayAnim(cache.ped, 'mini@repair', 'fixing_a_player', 2.0, 2.0, -1, 1, 0, false, false, false) -- This might be changed
+        TaskPlayAnim(cache.ped, 'mini@repair', 'fixing_a_player', 2.0, 2.0, -1, 1, 0, false, false, false)
 
         local success = lib.skillCheck({'easy', 'easy', {areaSize = 60, speedMultiplier = 2}, 'hard'}, {'w', 'a', 's', 'd'})
         if success then
@@ -345,9 +347,9 @@ if GetResourceState('ox_inventory') == 'started' then
             SetVehicleFixed(veh)
             SetVehicleEngineOn(veh, true, false, false)
             SetVehicleDoorShut(veh, doorIndex, false)
-            ClearPedTasks(cache.ped) -- This might be changed
+            ClearPedTasks(cache.ped)
         else
-            ClearPedTasks(cache.ped) -- This might be changed
+            ClearPedTasks(cache.ped)
             lib.notify({
                 description = 'You have failed!',
                 position = 'top-right',

--- a/client.lua
+++ b/client.lua
@@ -283,7 +283,7 @@ if GetResourceState('ox_inventory') == 'started' then
         local doorIndex = backEngine and 5 or 4
 
         SetVehicleDoorOpen(veh, doorIndex, false, false)
-        exports.scully_emotemenu:playEmoteByCommand('mechanic2')
+        TaskPlayAnim(cache.ped, 'mini@repair', 'fixing_a_player', 8.0, 8.0, -1, 1, 0, false, false, false) -- This might be changed
 
         local success = lib.skillCheck({'easy', 'easy', {areaSize = 60, speedMultiplier = 2}, 'hard'}, {'w', 'a', 's', 'd'})
         if success then
@@ -302,9 +302,9 @@ if GetResourceState('ox_inventory') == 'started' then
             end
             SetVehicleEngineOn(veh, true, false, false)
             SetVehicleDoorShut(veh, doorIndex, false)
-            exports.scully_emotemenu:cancelEmote()
+            ClearPedTasks(cache.ped) -- This might be changed
         else
-            exports.scully_emotemenu:cancelEmote()
+            ClearPedTasks(cache.ped) -- This might be changed
             lib.notify({
                 description = 'You have failed!',
                 position = 'top-right',
@@ -320,7 +320,7 @@ if GetResourceState('ox_inventory') == 'started' then
         local doorIndex = backEngine and 5 or 4
 
         SetVehicleDoorOpen(veh, doorIndex, false, false)
-        exports.scully_emotemenu:playEmoteByCommand('mechanic2')
+        TaskPlayAnim(cache.ped, 'mini@repair', 'fixing_a_player', 8.0, 8.0, -1, 1, 0, false, false, false) -- This might be changed
 
         local success = lib.skillCheck({'easy', 'easy', {areaSize = 60, speedMultiplier = 2}, 'hard'}, {'w', 'a', 's', 'd'})
         if success then
@@ -343,9 +343,9 @@ if GetResourceState('ox_inventory') == 'started' then
             SetVehicleFixed(veh)
             SetVehicleEngineOn(veh, true, false, false)
             SetVehicleDoorShut(veh, doorIndex, false)
-            exports.scully_emotemenu:cancelEmote()
+            ClearPedTasks(cache.ped) -- This might be changed
         else
-            exports.scully_emotemenu:cancelEmote()
+            ClearPedTasks(cache.ped) -- This might be changed
             lib.notify({
                 description = 'You have failed!',
                 position = 'top-right',

--- a/client.lua
+++ b/client.lua
@@ -29,7 +29,7 @@ local function startThreads()
                     torqueReduction = false
                     break
                 end
-    
+
                 Wait(1)
             end
 
@@ -126,7 +126,7 @@ local function startThreads()
 
             Wait(100)
         end
-        
+
         listening, airborne, torqueReduction = false, false, false
         speedBuffer, healthBuffer, bodyBuffer, roll = {0.0,0.0}, {0.0,0.0}, {0.0,0.0}, 0.0
     end)
@@ -169,3 +169,301 @@ RegisterNetEvent('vehiclehandler:client:adminfix', function()
         Utils.Vehicle.Repair(Vehicle:getEntity(), fuelscript)
     end
 end)
+
+-- Items
+if GetResourceState('ox_inventory') == 'started' then
+    -- Cleaning
+    local function CleanVehicle(veh)
+        if lib.progressCircle({
+            duration = math.random(10000, 20000),
+            position = 'middle',
+            label = 'Limpiando el vehículo',
+            useWhileDead = false,
+            canCancel = true,
+            disable = {
+                move = true,
+                car = true,
+                combat = false,
+                mouse = false,
+            },
+            anim = {
+                scenario = 'WORLD_HUMAN_MAID_CLEAN',
+            },
+        }) then
+            lib.notify({
+                description = 'Vehicle cleaned!',
+                position = 'top-right',
+                icon = 'soap',
+                type = 'success',
+            })
+            SetVehicleDirtLevel(veh, 0.1)
+            SetVehicleUndriveable(veh, false)
+            WashDecalsFromVehicle(veh, 1.0)
+            TriggerServerEvent('vehiclehandler:server:removewashingkit', veh)
+        else
+            lib.notify({
+                description = 'Cleaning aborted!',
+                position = 'top-right',
+                icon = 'soap',
+                type = 'error',
+            })
+        end
+    end
+
+    RegisterNetEvent('vehiclehandler:client:SyncWash', function(veh)
+        SetVehicleDirtLevel(veh, 0.1)
+        SetVehicleUndriveable(veh, false)
+        WashDecalsFromVehicle(veh, 1.0)
+    end)
+
+    RegisterNetEvent('vehiclehandler:client:CleanVehicle', function()
+        if not cache.ped then return end
+        local pos = GetEntityCoords(cache.ped)
+        local veh = lib.getClosestVehicle(pos, 3.0, true)
+        if veh ~= nil and veh ~= 0 then
+            local vehpos = GetEntityCoords(veh)
+            if #(pos - vehpos) < 3.0 and not IsPedInAnyVehicle(cache.ped, false) then
+                CleanVehicle(veh)
+            end
+        else
+            lib.notify({
+                description = 'You are not near a vehicle!',
+                position = 'top-right',
+                icon = 'toolbox',
+                type = 'error',
+            })
+        end
+    end)
+
+    -- Repairkits
+    BackEngineVehicles = {
+        [`ninef`] = true,
+        [`adder`] = true,
+        [`vagner`] = true,
+        [`t20`] = true,
+        [`infernus`] = true,
+        [`zentorno`] = true,
+        [`reaper`] = true,
+        [`comet2`] = true,
+        [`jester`] = true,
+        [`jester2`] = true,
+        [`cheetah`] = true,
+        [`cheetah2`] = true,
+        [`prototipo`] = true,
+        [`turismor`] = true,
+        [`pfister811`] = true,
+        [`ardent`] = true,
+        [`nero`] = true,
+        [`nero2`] = true,
+        [`tempesta`] = true,
+        [`vacca`] = true,
+        [`bullet`] = true,
+        [`osiris`] = true,
+        [`entityxf`] = true,
+        [`turismo2`] = true,
+        [`fmj`] = true,
+        [`re7b`] = true,
+        [`tyrus`] = true,
+        [`italigtb`] = true,
+        [`penetrator`] = true,
+        [`monroe`] = true,
+        [`ninef2`] = true,
+        [`stingergt`] = true,
+        [`surfer`] = true,
+        [`surfer2`] = true,
+        [`comet3`] = true,
+    }
+
+    local function IsBackEngine(vehModel)
+        if BackEngineVehicles[vehModel] then return true else return false end
+    end
+
+    local function RepairVehicle(veh)
+        local backEngine = IsBackEngine(GetEntityModel(veh))
+        local doorIndex = backEngine and 5 or 4
+
+        SetVehicleDoorOpen(veh, doorIndex, false, false)
+        exports.scully_emotemenu:playEmoteByCommand('mechanic2')
+
+        local success = lib.skillCheck({'easy', 'easy', {areaSize = 60, speedMultiplier = 2}, 'hard'}, {'w', 'a', 's', 'd'})
+        if success then
+            TriggerServerEvent('vehiclehandler:removeItem', "repairkit")
+            lib.notify({
+                description = 'Vehicle repaired!',
+                position = 'top-right',
+                icon = 'toolbox',
+                type = 'success',
+            })
+            SetVehicleUndriveable(veh, false)
+            SetVehicleEngineHealth(veh, 500.0)
+            for i = 0, 5 do
+                SetVehicleTyreFixed(veh, i)
+                SetVehicleWheelHealth(veh, i, 1000.0)
+            end
+            SetVehicleEngineOn(veh, true, false, false)
+            SetVehicleDoorShut(veh, doorIndex, false)
+            exports.scully_emotemenu:cancelEmote()
+        else
+            exports.scully_emotemenu:cancelEmote()
+            lib.notify({
+                description = 'You have failed!',
+                position = 'top-right',
+                icon = 'toolbox',
+                type = 'error',
+            })
+            SetVehicleDoorShut(veh, doorIndex, false)
+        end
+    end
+
+    local function RepairVehicleFull(veh)
+        local backEngine = IsBackEngine(GetEntityModel(veh))
+        local doorIndex = backEngine and 5 or 4
+
+        SetVehicleDoorOpen(veh, doorIndex, false, false)
+        exports.scully_emotemenu:playEmoteByCommand('mechanic2')
+
+        local success = lib.skillCheck({'easy', 'easy', {areaSize = 60, speedMultiplier = 2}, 'hard'}, {'w', 'a', 's', 'd'})
+        if success then
+            TriggerServerEvent('vehiclehandler:removeItem', "advancedrepairkit")
+            lib.notify({
+                description = 'Vehicle repaired!',
+                position = 'top-right',
+                icon = 'toolbox',
+                type = 'success',
+            })
+            SetVehicleUndriveable(veh, false)
+            SetVehicleEngineHealth(veh, 1000.0)
+            SetVehiclePetrolTankHealth(veh, 1000.0)
+            SetVehicleBodyHealth(veh, 1000.0)
+            ResetVehicleWheels(veh, true)
+            for i = 0, 5 do
+                SetVehicleTyreFixed(veh, i)
+                SetVehicleWheelHealth(veh, i, 1000.0)
+            end
+            SetVehicleFixed(veh)
+            SetVehicleEngineOn(veh, true, false, false)
+            SetVehicleDoorShut(veh, doorIndex, false)
+            exports.scully_emotemenu:cancelEmote()
+        else
+            exports.scully_emotemenu:cancelEmote()
+            lib.notify({
+                description = 'You have failed!',
+                position = 'top-right',
+                icon = 'toolbox',
+                type = 'error',
+            })
+            SetVehicleDoorShut(veh, doorIndex, false)
+        end
+    end
+
+    RegisterNetEvent('vehiclehandler:client:RepairVehicle', function()
+        if not cache.ped then return end
+        local pos = GetEntityCoords(cache.ped)
+        local veh = lib.getClosestVehicle(pos, 10.0, true)
+        local engineHealth = GetVehicleEngineHealth(veh)
+        if veh ~= nil and veh ~= 0 and engineHealth > -1.0 then -- Check if vehicle is destroyed
+            if veh ~= nil and veh ~= 0 and engineHealth < 500 then
+                local vehpos = GetEntityCoords(veh)
+                if #(pos - vehpos) < 5.0 and not IsPedInAnyVehicle(cache.ped, false) then
+                    local drawpos = GetOffsetFromEntityInWorldCoords(veh, 0, 2.5, 0)
+                    if (IsBackEngine(GetEntityModel(veh))) then
+                        drawpos = GetOffsetFromEntityInWorldCoords(veh, 0, -2.5, 0)
+                    end
+                    if #(pos - drawpos) < 2.0 and not IsPedInAnyVehicle(cache.ped, false) then
+                        RepairVehicle(veh)
+                    end
+                else
+                    if #(pos - vehpos) > 4.9 then
+                        lib.notify({
+                            description = 'You are too far from the vehicle!',
+                            position = 'top-right',
+                            icon = 'toolbox',
+                            type = 'error',
+                        })
+                    else
+                        lib.notify({
+                            description = 'The vehicle\'s engine cannot be repaired from the interior!',
+                            position = 'top-right',
+                            icon = 'toolbox',
+                            type = 'error',
+                        })
+                    end
+                end
+            else
+                if veh == nil or veh == 0 then
+                    lib.notify({
+                        description = 'You are not near a vehicle!',
+                        position = 'top-right',
+                        icon = 'toolbox',
+                        type = 'error',
+                    })
+                else
+                    lib.notify({
+                        description = 'The vehicle is fine and needs better tools!',
+                        position = 'top-right',
+                        icon = 'toolbox',
+                        type = 'error',
+                    })
+                end
+            end
+        else
+            lib.notify({
+                description = 'This vehicle is destroyed and cannot be repaired',
+                position = 'top-right',
+                icon = 'toolbox',
+                type = 'error',
+            })
+        end
+    end)
+
+    RegisterNetEvent('vehiclehandler:client:RepairVehicleFull', function()
+        if not cache.ped then return end
+        local pos = GetEntityCoords(cache.ped)
+        local veh = lib.getClosestVehicle(pos, 10.0, true)
+        local engineHealth = GetVehicleEngineHealth(veh)
+        if veh ~= nil and veh ~= 0 and engineHealth > -1.0 then -- Check if vehicle is destroyed
+            if veh ~= nil and veh ~= 0 then
+                local vehpos = GetEntityCoords(veh)
+                if #(pos - vehpos) < 5.0 and not IsPedInAnyVehicle(cache.ped, false) then
+                    local drawpos = GetOffsetFromEntityInWorldCoords(veh, 0, 2.5, 0)
+                    if (IsBackEngine(GetEntityModel(veh))) then
+                        drawpos = GetOffsetFromEntityInWorldCoords(veh, 0, -2.5, 0)
+                    end
+                    if #(pos - drawpos) < 2.0 and not IsPedInAnyVehicle(cache.ped, false) then
+                        RepairVehicleFull(veh)
+                    end
+                else
+                    if #(pos - vehpos) > 4.9 then
+                        lib.notify({
+                            description = 'You are too far from the vehicle!',
+                            position = 'top-right',
+                            icon = 'toolbox',
+                            type = 'error',
+                        })
+                    else
+                        lib.notify({
+                            description = 'The vehicle\'s engine cannot be repaired from the interior!',
+                            position = 'top-right',
+                            icon = 'toolbox',
+                            type = 'error',
+                        })
+                    end
+                end
+            else
+                lib.notify({
+                    description = 'You are not near a vehicle!',
+                    position = 'top-right',
+                    icon = 'toolbox',
+                    type = 'error',
+                })
+            end
+        else
+            lib.notify({
+                description = 'This vehicle is destroyed and cannot be repaired',
+                position = 'top-right',
+                icon = 'toolbox',
+                type = 'error',
+            })
+        end
+    end)
+end

--- a/client.lua
+++ b/client.lua
@@ -177,7 +177,7 @@ if GetResourceState('ox_inventory') == 'started' then
         if lib.progressCircle({
             duration = math.random(10000, 20000),
             position = 'middle',
-            label = 'Limpiando el vehículo',
+            label = 'Cleaning the vehicle',
             useWhileDead = false,
             canCancel = true,
             disable = {

--- a/client.lua
+++ b/client.lua
@@ -283,7 +283,8 @@ if GetResourceState('ox_inventory') == 'started' then
         local doorIndex = backEngine and 5 or 4
 
         SetVehicleDoorOpen(veh, doorIndex, false, false)
-        TaskPlayAnim(cache.ped, 'mini@repair', 'fixing_a_player', 8.0, 8.0, -1, 1, 0, false, false, false) -- This might be changed
+        lib.requestAnimDict('mini@repair')
+        TaskPlayAnim(cache.ped, 'mini@repair', 'fixing_a_player', 2.0, 2.0, -1, 1, 0, false, false, false) -- This might be changed
 
         local success = lib.skillCheck({'easy', 'easy', {areaSize = 60, speedMultiplier = 2}, 'hard'}, {'w', 'a', 's', 'd'})
         if success then
@@ -320,7 +321,8 @@ if GetResourceState('ox_inventory') == 'started' then
         local doorIndex = backEngine and 5 or 4
 
         SetVehicleDoorOpen(veh, doorIndex, false, false)
-        TaskPlayAnim(cache.ped, 'mini@repair', 'fixing_a_player', 8.0, 8.0, -1, 1, 0, false, false, false) -- This might be changed
+        lib.requestAnimDict('mini@repair')
+        TaskPlayAnim(cache.ped, 'mini@repair', 'fixing_a_player', 2.0, 2.0, -1, 1, 0, false, false, false) -- This might be changed
 
         local success = lib.skillCheck({'easy', 'easy', {areaSize = 60, speedMultiplier = 2}, 'hard'}, {'w', 'a', 's', 'd'})
         if success then

--- a/data/vehicle.lua
+++ b/data/vehicle.lua
@@ -1,5 +1,5 @@
 return {
-    units = 'mph' ,         -- (mph, kmh)
+    units = 'kmh' ,         -- (mph, kmh)
     threshold = {
         health = 50.0,      -- Health difference needed to break off wheel (LastHealth - CurrentHealth)
         speed = 50.0,       -- Speed difference needed to trigger collision events (LastSpeed - CurrentSpeed)

--- a/modules/utils.lua
+++ b/modules/utils.lua
@@ -51,7 +51,7 @@ end
 function Utils.Vehicle.Repair(veh, script)
     lib.callback('vehiclehandler:server:sync', -1, function()
         SetVehicleUndriveable(veh, false)
-        SetVehicleEngineHealth(veh, 1000,0)
+        SetVehicleEngineHealth(veh, 1000.0)
         SetVehiclePetrolTankHealth(veh, 1000.0)
         SetVehicleBodyHealth(veh, 1000.0)
         ResetVehicleWheels(veh, true)
@@ -68,8 +68,8 @@ function Utils.Vehicle.Repair(veh, script)
             SetVehicleFuelLevel(veh, 100.0)
             DecorSetFloat(veh, '_FUEL_LEVEL', GetVehicleFuelLevel(vehicle))
         end
-        
-        SetVehicleEngineOn(veh, true, true)
+
+        SetVehicleEngineOn(veh, true, true, false)
     end)
 end
 

--- a/server.lua
+++ b/server.lua
@@ -25,7 +25,7 @@ end)
 
 lib.addCommand('fix', {
     help = 'Repair current vehicle',
-    restricted = 'qbcore.god'
+    restricted = 'group.admin'
 }, function(source, args, raw)
     TriggerClientEvent('vehiclehandler:client:adminfix', source)
 end)

--- a/server.lua
+++ b/server.lua
@@ -25,7 +25,21 @@ end)
 
 lib.addCommand('fix', {
     help = 'Repair current vehicle',
-    restricted = 'group.admin'
+    restricted = 'qbcore.god'
 }, function(source, args, raw)
     TriggerClientEvent('vehiclehandler:client:adminfix', source)
 end)
+
+-- Items
+if GetResourceState('ox_inventory') == 'started' then
+    RegisterNetEvent('vehiclehandler:removeItem', function(item)
+        local src = source
+        exports.ox_inventory:RemoveItem(src, item, 1)
+    end)
+
+    RegisterNetEvent('vehiclehandler:server:removewashingkit', function(veh)
+        local src = source
+        exports.ox_inventory:RemoveItem(src, 'cleaningkit', 1)
+        TriggerClientEvent('vehiclehandler:client:SyncWash', -1, veh)
+    end)
+end


### PR DESCRIPTION
This pull request is aimed at adding the functionality to use items using solely ox_lib and ox_inventory. Consequently, it is not dependent on any specific framework. While it may benefit from better integration with the vehiclehandler utils in the future, it currently functions perfectly and serves as a solid starting point for implementation.

# Installation steps
- Go to ``ox_inventory/data/items.lua`` and add the following items:
```lua
	["cleaningkit"] = {
		label = "Cleaning Kit",
		weight = 50
		stack = true,
		close = true,
		description = "Your description goes here",
	},

	['repairkit'] = {
		label = 'Repair Kit',
		weight = 2500,
		stack = true,
		close = true,
		description = "Your description goes here"
	},

	['advancedrepairkit'] = {
		label = 'Advanced Repair Kit',
		weight = 2500,
		stack = true,
		close = true,
		description = "Your description goes here"
	},
```
- Go to ``ox_inventory/modules/items/client.lua`` and add the following:
```lua
Item('cleaningkit', function(data, slot)
	TriggerEvent('vehiclehandler:client:CleanVehicle', source)
end)

Item('repairkit', function(data, slot)
	TriggerEvent('vehiclehandler:client:RepairVehicle', source)
end)

Item('advancedrepairkit', function(data, slot)
	TriggerEvent('vehiclehandler:client:RepairVehicleFull', source)
end)
```
- Restart your server and you're ready to go. Don't forget to remove ``qb-vehiclefailure`` from your resources folder.