### PR TITLE
Add configurable exclusion list for regulated vehicle controls

### DIFF
--- a/client.lua
+++ b/client.lua
@@ -6,6 +6,14 @@ local Handler = require 'modules.handler'
 local Settings = lib.load('data.vehicle')
 local Units = Settings.units == 'mph' and 2.23694 or 3.6
 
+-- Process the exclusion list into a hash set for efficient lookups
+local RegulatedExclusions = {}
+if Settings.regulated_exclusions then
+    for model, _ in pairs(Settings.regulated_exclusions) do
+        RegulatedExclusions[GetHashKey(model)] = true
+    end
+end
+
 local function startThread(vehicle)
     if not vehicle then return end
     if not Handler or Handler:isActive() then return end
@@ -70,8 +78,11 @@ local function startThread(vehicle)
             end
 
             -- Prevent rotation controls while flipped/airborne
-            if Settings.regulated[class] then
+            local modelHash = GetEntityModel(vehicle)
+            if Settings.regulated[class] and not RegulatedExclusions[modelHash] then
                 local roll, airborne = 0.0, false
+
+                if speed < 2.0 then
 
                 if speed < 2.0 then
                     roll = GetEntityRoll(vehicle)

--- a/client.lua
+++ b/client.lua
@@ -6,14 +6,6 @@ local Handler = require 'modules.handler'
 local Settings = lib.load('data.vehicle')
 local Units = Settings.units == 'mph' and 2.23694 or 3.6
 
--- Process the exclusion list into a hash set for efficient lookups
-local RegulatedExclusions = {}
-if Settings.regulated_exclusions then
-    for model, _ in pairs(Settings.regulated_exclusions) do
-        RegulatedExclusions[GetHashKey(model)] = true
-    end
-end
-
 local function startThread(vehicle)
     if not vehicle then return end
     if not Handler or Handler:isActive() then return end
@@ -78,8 +70,7 @@ local function startThread(vehicle)
             end
 
             -- Prevent rotation controls while flipped/airborne
-            local modelHash = GetEntityModel(vehicle)
-            if Settings.regulated[class] and RegulatedExclusions[modelHash] then
+            if Settings.regulated[class] and not Settings.regulated_exclusions[GetEntityModel(vehicle)] then
                 local roll, airborne = 0.0, false
 
                 if speed < 2.0 then

--- a/client.lua
+++ b/client.lua
@@ -83,8 +83,6 @@ local function startThread(vehicle)
                 local roll, airborne = 0.0, false
 
                 if speed < 2.0 then
-
-                if speed < 2.0 then
                     roll = GetEntityRoll(vehicle)
                 else
                     airborne = IsEntityInAir(vehicle)

--- a/client.lua
+++ b/client.lua
@@ -79,7 +79,7 @@ local function startThread(vehicle)
 
             -- Prevent rotation controls while flipped/airborne
             local modelHash = GetEntityModel(vehicle)
-            if Settings.regulated[class] and not RegulatedExclusions[modelHash] then
+            if Settings.regulated[class] and RegulatedExclusions[modelHash] then
                 local roll, airborne = 0.0, false
 
                 if speed < 2.0 then

--- a/data/vehicle.lua
+++ b/data/vehicle.lua
@@ -60,6 +60,7 @@ return {
     regulated_exclusions = {    -- Prevent rotation controls for these specific models, even if their class is regulated
         [`deluxo`] = true,
         [`scramjet`] = true,
+        [`vigilante`] = true,
     },
     backengine = {
         [`ninef`] = true,

--- a/data/vehicle.lua
+++ b/data/vehicle.lua
@@ -57,6 +57,10 @@ return {
                 false,          -- 21: Trains
                 true,           -- 22: Open Wheel
     },
+    regulated_exclusions = {    -- Prevent rotation controls for these specific models, even if their class is regulated
+        [`deluxo`] = true,
+        [`scramjet`] = true,
+    },
     backengine = {
         [`ninef`] = true,
         [`adder`] = true,


### PR DESCRIPTION
This pull request introduces a new, flexible way for server owners to exclude specific vehicle models from the "Prevent rotation controls while flipped/airborne" feature directly through the configuration file.

**The Problem:**
Currently, if a server owner wants to exempt a vehicle with special abilities (like the Deluxo or Scramjet) from the control lock, they must manually edit the core script files. This makes customization difficult and can create conflicts when the resource is updated in the future.

**The Solution:**
This patch implements a much simpler approach to managing exclusions:

1.  **New Configuration Table:** A new `regulated_exclusions` table has been added to `data/vehicle.lua`. Server owners can now simply list the model names of any vehicle they wish to exclude.
    ```lua
    -- data/vehicle.lua
    regulated_exclusions = {
        [`deluxo`] = true,
        [`scramjet`] = true,
    }
    ```

2.  **Updated Script Logic:** The main script now reads this new list at startup and will automatically bypass the control lock for any vehicle models found in it. The check is performed efficiently to ensure there is no performance impact.

This approach moves all vehicle customization into the config file where it belongs. It makes the resource much easier for server administrators to manage and simplifies the process of applying future updates.